### PR TITLE
[ BB2-984 ] Adding support for handling the rejection

### DIFF
--- a/server/src/utils/userUtil.py
+++ b/server/src/utils/userUtil.py
@@ -11,3 +11,16 @@ DEVELOPER NOTES:
 
 def getLoggedInUser():
     return DBusers[0]
+
+def clearBB2Data():
+    logged_in_user = getLoggedInUser()
+    logged_in_user.update({'authToken': {
+        'access_token' : '',
+        'expires_in' : 0,
+        'expires_at' : 0,
+        'token_type' : '',
+        'scope' : '',
+        'refresh_token' : '',
+        'patient' : ''
+    }})
+    logged_in_user.update({'eobData': ''})


### PR DESCRIPTION
This PR is to fix the use case where at first the beneficiary grants the application access to their data. Then in the future they deny access for the application. It also shows the application what we recommend in that situation (which is to remove all of the data they have on that beneficiary).