### PR TITLE
[ BB2-936 ] Adding support for using the refresh token

### DIFF
--- a/server/src/app/views.py
+++ b/server/src/app/views.py
@@ -72,7 +72,7 @@ def authorizationCallback():
         configSettings = getConfigSettings(myEnv)
 
         # this gets the token from Medicare.gov once the 'user' authenticates their Medicare.gov account
-        response = getAccessToken(requestQuery.get('code'),requestQuery.get('state'),configSettings=configSettings,settings=settings)
+        authToken = getAccessToken(requestQuery.get('code'),requestQuery.get('state'),configSettings=configSettings,settings=settings)
         
         """DEVELOPER NOTES:
         * This is where you would most likely place some type of
@@ -82,7 +82,6 @@ def authorizationCallback():
         * Here we are however, just updating the loggedInUser we pulled from our MockDb, but we aren't persisting that change
         * back into our mocked DB, normally you would want to do this
         """
-        authToken = json.loads(response.text)
         
         #Here we are grabbing the mocked 'user' for our application
         # to be able to store the access token for that user


### PR DESCRIPTION
Making sure to save the expired at time when the token is first fetched. Then using that time to determine when it has expired to fetch a new token. Doing it only on EOB since that is the only data source we have implemented. Can reference this PR for more details - https://github.com/CMSgov/bluebutton-sample-client-nodejs-react/pull/10