### PR TITLE
jimfuqian/BB2-3311 Remove selenium tests webdriver opt setting window-size

### DIFF
--- a/selenium_tests/src/test_python_sample.py
+++ b/selenium_tests/src/test_python_sample.py
@@ -28,7 +28,6 @@ class TestNodeSampleApp():
         opt.add_argument("--disable-popup-blocking")
         opt.add_argument("--enable-javascript")
         opt.add_argument('--allow-insecure-localhost')
-        opt.add_argument('--window-size=1920,1080')
         opt.add_argument("--whitelisted-ips=''")
 
         # opt.add_argument('--headless')


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3311](https://jira.cms.gov/browse/BB2-3311)

### What Does This PR Do?

Remove Selenium Chrome webdriver opt setting: window-size
this results in the selenium tests VNC web UI rendering takes the default viewport setting which is preferred - page content centered and proportioned in the VNC view, better for tests user interaction checking and trouble shooting.

<!--
Add detailed description & discussion of changes here.
-->

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->
Check out the PR to local and run a selenium tests remote or local
Start VNC viewer and observe the web UI interaction in VNC viewer
Expected: the web UI should be centered

Refer to this BB2 web server PR for VNC setup details:
https://github.com/CMSgov/bluebutton-web-server/pull/1248
