### PR TITLE
Make axios be 1.16.0 or above

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react-swc": "^3.7.2",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "micromatch": "4.0.8",
     "process": "^0.11.10",
     "react": "^18.2.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2823,7 +2823,7 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.12.0.tgz#16dc230cc0a8a2732e723ce76a0395df9ba7a788"
   integrity sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==
 
-axios@^1.15.0:
+axios@^1.16.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
   integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==


### PR DESCRIPTION
JIRA Ticket:
[BB2-4852](https://jira.cms.gov/browse/BB2-4852)

What Does This PR Do?
Upgrade axios to version 1.16.0 or higher.

What Should Reviewers Watch For?
If you're reviewing this PR, please check for these things in particular:

Validation
- Pull down the branch and cd into the client directory
    - Run yarn install
    - Go back to the root of the directory and run `docker-compose up -d`
    - Run `docker ps` and get the client container docker id to put in the next command
    - Exec into running container: `docker exec -it insert-docker-client-id-here /bin/bash`
    - Run `yarn why axios` and verify that it's a higher version than 1.16.0 (it will probably be 1.17.0)
    - Navigate to localhost:3000 and ensure the auth flow still works