### PR TITLE
adding libssh upgrade and changing to slim-trixie

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 # In case machine is Mac M1 chip
 RUN apt-get update && \
-    apt-get install -y libcap2 python3 python3-pip
+    apt-get install -y libcap2 python3 python3-pip libssh2-1
 
 RUN yarn install
 # comment build out if not going to use preview to save build time

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim-trixie
 
 ARG BUILD_DEVELOPMENT="False"
 
@@ -10,9 +10,10 @@ WORKDIR /server
 
 COPY . . 
 
-# Upgrade libgnutls30 to patched version (Debian 12 >= 3.7.9-2+deb12u7)
+
+# Upgrade libssh2-1 to patched version (Debian 13 >= 1.11.1-1+deb13u1)
 RUN apt-get update && \
-    apt-get install -y libgnutls30
+    apt-get install -y libgnutls30 libssh2-1
 
 RUN pip install pipenv debugpy
 


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-4954](https://jira.cms.gov/browse/BB2-4954)


### What Does This PR Do?
Upgrades libssh2 to be a later version. Since apt-get uses the latest on whatever image it is running on, the 3.11 image had to be changed to slim-trixie to get a later version with less disruption

### What Should Reviewers Watch For?
Any breaking portions of the site


### Validation

Run locally with docker compose up from the base repository
